### PR TITLE
build: set better timeout

### DIFF
--- a/.github/workflows/inclusivelint.yml
+++ b/.github/workflows/inclusivelint.yml
@@ -4,6 +4,7 @@ jobs:
   inclusivelint:
     runs-on: ubuntu-latest
     name: Inclusivelint
+    timeout-minutes: 60
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2


### PR DESCRIPTION
Set missing timeouts to 60 to avoid using the default of 6 hours.

See https://github.com/Doist/Issues/issues/5259