### PR TITLE
chore: Update actions to support NodeJS 20

### DIFF
--- a/.github/workflows/inclusivelint.yml
+++ b/.github/workflows/inclusivelint.yml
@@ -7,7 +7,7 @@ jobs:
     timeout-minutes: 60
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Lint for non-inclusive words
       uses: Doist/inclusivelint@v2
       with:


### PR DESCRIPTION
This PR updates the actions to versions that no longer rely on NodeJS 16, which has reached its end of life. By upgrading the actions, we ensure compatibility with the latest NodeJS 20 runtime.

For https://github.com/Doist/infrastructure-backlog/issues/628
